### PR TITLE
fix: have ipv4 addresses match their ipv6 version

### DIFF
--- a/lib/ipfilter.js
+++ b/lib/ipfilter.js
@@ -88,7 +88,7 @@ module.exports = function ipfilter(ips, opts) {
   }
 
   const testExplicitIp = (ip, constraint, mode) => {
-    if (ip === constraint) {
+    if (iputil.isEqual(ip, constraint)) {
       return mode === 'allow'
     } else {
       return mode === 'deny'
@@ -111,7 +111,7 @@ module.exports = function ipfilter(ips, opts) {
         const longIp = iputil.toLong(ip)
         return longIp >= startIp && longIp <= endIp
       } else {
-        return ip === constraint[0]
+        return iputil.isEqual(ip, constraint[0])
       }
     })
 


### PR DESCRIPTION
This switches to comparing ip addresses with `require("ip").isEqual` instead of `===`. This should better support IPv6, where the same address can be written in multiple formats, and it should also address the case where a Node server is listening on an IPv6 socket that also accepts IPv4 connections (in which case proxy-addr returns the IPv4-mapped IPv6 address).