### PR TITLE
Include IP in `extra` on `IpDeniedError`

### DIFF
--- a/lib/ipfilter.js
+++ b/lib/ipfilter.js
@@ -152,7 +152,7 @@ module.exports = function ipfilter(ips, opts) {
   }
 
   const error = (ip, next) => {
-    const err = new IpDeniedError('Access denied to IP address: ' + ip)
+    const err = new IpDeniedError('Access denied to IP address: ' + ip, { ip })
     return next(err)
   }
 


### PR DESCRIPTION
This would be useful when reformatting or filtering errors, or for collecting metrics, by being able to see the denied error in our express error handler as error.extra.ip rather than having to substring it out from the error message